### PR TITLE
Fix currentMonster initialization typo

### DIFF
--- a/js/pve.js
+++ b/js/pve.js
@@ -8,7 +8,7 @@ class PVE {
     constructor(playerLingChong) {
         this.playerLingChong = playerLingChong;
         this.currentLevel = 0; // 当前挑战的关卡索引 (从0开始)
-        this.currentMonster = nullee;
+        this.currentMonster = null;
         this.isInBattle = false;
         this.battleLog = [];
         this.battleSpeed = 1; // 1x, 2x, 3x


### PR DESCRIPTION
## Summary
- initialize `currentMonster` to `null` in the PVE constructor to prevent runtime errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7300f9d0c83238d1f57c4802acd7b